### PR TITLE
refactor(Dockerfile): use wildcard to simplify composer file copy commands

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -5,8 +5,7 @@ COPY ./docker/docker-entrypoint.sh ./docker/docker-entrypoint.sh
 COPY ./src ./src
 COPY ./docs/rules-v1.json ./docs/rules-v1.json
 COPY php-version-audit .
-COPY ./composer.json .
-COPY ./composer.lock .
+COPY ./composer.* .
 RUN composer install            \
     --classmap-authoritative    \
     --no-dev                    \

--- a/docker/Dockerfile.bookworm
+++ b/docker/Dockerfile.bookworm
@@ -5,8 +5,7 @@ COPY ./docker/docker-entrypoint.sh ./docker/docker-entrypoint.sh
 COPY ./src ./src
 COPY ./docs/rules-v1.json ./docs/rules-v1.json
 COPY php-version-audit .
-COPY ./composer.json .
-COPY ./composer.lock .
+COPY ./composer.* .
 RUN composer install            \
     --classmap-authoritative    \
     --no-dev                    \

--- a/docker/Dockerfile.bullseye
+++ b/docker/Dockerfile.bullseye
@@ -5,8 +5,7 @@ COPY ./docker/docker-entrypoint.sh ./docker/docker-entrypoint.sh
 COPY ./src ./src
 COPY ./docs/rules-v1.json ./docs/rules-v1.json
 COPY php-version-audit .
-COPY ./composer.json .
-COPY ./composer.lock .
+COPY ./composer.* .
 RUN composer install            \
     --classmap-authoritative    \
     --no-dev                    \


### PR DESCRIPTION
### Summary

This pull request refactors the Dockerfile by consolidating the copy commands for `composer.json` and `composer.lock` into a single command using a wildcard. 

### Changes Made
- Updated the Dockerfile to use `COPY ./composer.* .` instead of separate copy commands.

### Benefits
- Simplifies the Dockerfile and reduces redundancy.
- Makes it easier to add more composer-related files in the future if necessary.

Please review the changes and let me know if there are any questions!
